### PR TITLE
Auto generate tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@
 XXXX-XX-XX
 
 - Add ``MemoryLeakTestCase.auto_generate``, to auto-generate test methods from
-  a declarative dictionary.
+  a declarative specification.
 - warm internal python caches before starting measurements (avoid possible
   false positives on the very first run)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@
 
 XXXX-XX-XX
 
+- Add ``MemoryLeakTestCase.auto_generate``, to auto-generate test methods from
+  a declarative dictionary.
 - warm internal python caches before starting measurements (avoid possible
   false positives on the very first run)
 

--- a/README.rst
+++ b/README.rst
@@ -183,17 +183,19 @@ specification:
     from psleak import MemoryLeakTestCase, LeakTest
 
     class TestNumpyLeaks(MemoryLeakTestCase):
-        auto_generate = {
-            "zeros": LeakTest(np.zeros, 10),
-            "add": LeakTest(np.add, 1, 2),
-            "custom": LeakTest(
-                np.dot,
-                [1, 2],
-                [3, 4],
-                times=10,
-                tolerance=1024,
-            ),
-        }
+        @classmethod
+        def auto_generate(cls):
+            return {
+                "zeros": LeakTest(np.zeros, 10),
+                "add": LeakTest(np.add, 1, 2),
+                "custom": LeakTest(
+                    np.dot,
+                    [1, 2],
+                    [3, 4],
+                    times=10,
+                    tolerance=1024,
+                ),
+            }
 
 This will define the following test methods: ``test_leak_zeros``,
 ``test_leak_add``, ``test_leak_custom``.

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,8 @@ You can override these either when calling ``execute()``:
 Auto-generate tests
 ===================
 
-Tests can also be auto-generated like this:
+MemoryLeakTestCase can auto-generate test methods from a declarative
+dictionary:
 
 .. code-block:: python
 
@@ -182,30 +183,20 @@ Tests can also be auto-generated like this:
 
     class TestNumpyLeaks(MemoryLeakTestCase):
         auto_generate = {
-            "add": (np.add, 1, 2),
-            "sqrt": (np.sqrt, 1.0),
+            # simple callable
             "zeros": lambda: np.zeros(10),
-            "ones": (np.ones, 10),
-            "dot": (np.dot, [1, 2], [3, 4]),
-        }
-
-This automatically defines ``test_leak_add``, ``test_leak_sqrt``,
-``test_leak_zeros``, ``test_leak_ones``, and ``test_leak_dot`` methods.
-
-You can also override ``MemoryLeakTestCase.execute()`` kwargs per test:
-
-.. code-block:: python
-
-    class TestCustom(MemoryLeakTestCase):
-        auto_generate = {
+            # callable with arguments (tuple)
+            "add": (np.add, 1, 2),
+            # dict with 'call' and per-test execute() overrides
             "custom": {
-                "call": lambda: None,
+                "call": (np.dot, [1, 2], [3, 4]),
                 "times": 10,
                 "tolerance": 1024,
-            }
+            },
         }
 
-This sets ``times=10`` and ``tolerance=1024`` for the test_leak_custom method.
+This automatically defines the following test methods: ``test_leak_zeros``,
+``test_leak_add``, ``test_leak_custom``.
 
 Recommended test environment
 ============================

--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,20 @@ Tests can also be auto-generated like this:
 This automatically defines ``test_leak_add``, ``test_leak_sqrt``,
 ``test_leak_zeros``, ``test_leak_ones``, and ``test_leak_dot`` methods.
 
+You can also override ``MemoryLeakTestCase.execute()`` kwargs per test:
+
+.. code-block:: python
+
+    class TestCustom(MemoryLeakTestCase):
+        auto_generate = {
+            "custom": {
+                "call": lambda: None,
+                "times": 10,
+                "tolerance": 1024,
+            }
+        }
+
+This sets ``times=10`` and ``tolerance=1024`` for the test_leak_custom method.
 
 Recommended test environment
 ============================

--- a/README.rst
+++ b/README.rst
@@ -184,13 +184,14 @@ Tests can also be auto-generated like this:
         auto_generate = {
             "add": (np.add, 1, 2),
             "sqrt": (np.sqrt, 1.0),
-            "zeros": (np.zeros, 10),
+            "zeros": lambda: np.zeros(10),
             "ones": (np.ones, 10),
             "dot": (np.dot, [1, 2], [3, 4]),
         }
 
 This automatically defines ``test_leak_add``, ``test_leak_sqrt``,
 ``test_leak_zeros``, ``test_leak_ones``, and ``test_leak_dot`` methods.
+
 
 Recommended test environment
 ============================

--- a/README.rst
+++ b/README.rst
@@ -172,30 +172,30 @@ You can override these either when calling ``execute()``:
 Auto-generate tests
 ===================
 
-MemoryLeakTestCase can auto-generate test methods from a declarative
-dictionary:
+In order to avoid writing many similar test methods by hand,
+``MemoryLeakTestCase`` can auto-generate test methods from a declarative
+specification:
 
 .. code-block:: python
 
     import numpy as np
 
-    from psleak import MemoryLeakTestCase
+    from psleak import MemoryLeakTestCase, LeakTest
 
     class TestNumpyLeaks(MemoryLeakTestCase):
         auto_generate = {
-            # simple callable
-            "zeros": lambda: np.zeros(10),
-            # callable with arguments (tuple)
-            "add": (np.add, 1, 2),
-            # dict with 'call' and per-test execute() overrides
-            "custom": {
-                "call": (np.dot, [1, 2], [3, 4]),
-                "times": 10,
-                "tolerance": 1024,
-            },
+            "zeros": LeakTest(np.zeros, 10),
+            "add": LeakTest(np.add, 1, 2),
+            "custom": LeakTest(
+                np.dot,
+                [1, 2],
+                [3, 4],
+                times=10,
+                tolerance=1024,
+            ),
         }
 
-This automatically defines the following test methods: ``test_leak_zeros``,
+This defines the following test methods: ``test_leak_zeros``,
 ``test_leak_add``, ``test_leak_custom``.
 
 Recommended test environment

--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ specification:
             ),
         }
 
-This defines the following test methods: ``test_leak_zeros``,
+This will define the following test methods: ``test_leak_zeros``,
 ``test_leak_add``, ``test_leak_custom``.
 
 Recommended test environment

--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,29 @@ You can override these either when calling ``execute()``:
         def test_fun(self):
             self.execute(some_function)
 
+Auto-generate tests
+===================
+
+Tests can also be auto-generated like this:
+
+.. code-block:: python
+
+    import numpy as np
+
+    from psleak import MemoryLeakTestCase
+
+    class TestNumpyLeaks(MemoryLeakTestCase):
+        auto_generate = {
+            "add": (np.add, 1, 2),
+            "sqrt": (np.sqrt, 1.0),
+            "zeros": (np.zeros, 10),
+            "ones": (np.ones, 10),
+            "dot": (np.dot, [1, 2], [3, 4]),
+        }
+
+This automatically defines ``test_leak_add``, ``test_leak_sqrt``,
+``test_leak_zeros``, ``test_leak_ones``, and ``test_leak_dot`` methods.
+
 Recommended test environment
 ============================
 

--- a/psleak.py
+++ b/psleak.py
@@ -363,7 +363,7 @@ def _emit_warnings():
 
 
 class LeakTest:
-    """A small helper object to use in conjunction with
+    """Small helper object to use in conjunction with
     ``MemoryLeakTestCase.auto_generate``.
     """
 

--- a/psleak.py
+++ b/psleak.py
@@ -398,10 +398,10 @@ class MemoryLeakTestCase(unittest.TestCase):
     trim_callback = None
     # Config object which tells which checkers to run.
     checkers = Checkers()
-    # 0 = no messages; 1 = print diagnostics when memory increases.
-    verbosity = 1
     # Declarative auto-generated tests.
     auto_generate = None
+    # 0 = no messages; 1 = print diagnostics when memory increases.
+    verbosity = 1
 
     __doc__ = __doc__
 

--- a/psleak.py
+++ b/psleak.py
@@ -389,7 +389,9 @@ class MemoryLeakTestCase(unittest.TestCase):
         warm_caches()
 
     def __init_subclass__(cls, **kwargs):
-        def make_test(fun, execute_kwargs):
+        super().__init_subclass__(**kwargs)
+
+        def make_test(fun, execute_kwargs, test_name, name):
             def test(self):
                 self.execute(fun, **execute_kwargs)
 
@@ -397,8 +399,6 @@ class MemoryLeakTestCase(unittest.TestCase):
             test.__qualname__ = test_name
             test.__doc__ = f"Auto-generated leak test for {name}"
             return test
-
-        super().__init_subclass__(**kwargs)
 
         calls = getattr(cls, "auto_generate", None)
         if not calls:
@@ -451,7 +451,9 @@ class MemoryLeakTestCase(unittest.TestCase):
                 msg = f"{cls.__name__} already defines {test_name}"
                 raise RuntimeError(msg)
 
-            setattr(cls, test_name, make_test(fun, execute_kwargs))
+            setattr(
+                cls, test_name, make_test(fun, execute_kwargs, test_name, name)
+            )
 
     @classmethod
     def setUpClass(cls):

--- a/psleak.py
+++ b/psleak.py
@@ -367,21 +367,18 @@ class LeakTest:
     ``MemoryLeakTestCase.auto_generate``.
     """
 
-    __slots__ = ("args", "call", "execute_kwargs")
+    __slots__ = ("args", "execute_kwargs", "fun")
 
-    def __init__(self, call, *args, **execute_kwargs):
-        if not callable(call):
-            msg = "LeakTest 'call' must be callable"
-            raise TypeError(msg)
-
-        self.call = call
+    def __init__(self, fun, *args, **execute_kwargs):
+        assert_isinstance("fun", fun, collections.abc.Callable)
+        self.fun = fun
         self.args = args
         self.execute_kwargs = dict(execute_kwargs)
 
     def _make_callable(self):
         if self.args:
-            return functools.partial(self.call, *self.args)
-        return self.call
+            return functools.partial(self.fun, *self.args)
+        return self.fun
 
 
 class MemoryLeakTestCase(unittest.TestCase):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -364,7 +364,7 @@ class TestAutoGenerate(unittest.TestCase):
     def test_simple_leaktest(self):
         calls = []
 
-        class T(MemoryLeakTestCase):
+        class Test(MemoryLeakTestCase):
             auto_generate = {
                 "foo": LeakTest(lambda: None),
             }
@@ -372,8 +372,8 @@ class TestAutoGenerate(unittest.TestCase):
             def execute(self, fun, **kwargs):
                 calls.append((fun, kwargs))
 
-        t = T("test_leak_foo")
-        t.test_leak_foo()
+        test = Test("test_leak_foo")
+        test.test_leak_foo()
 
         assert len(calls) == 1
         fun, kwargs = calls[0]
@@ -387,7 +387,7 @@ class TestAutoGenerate(unittest.TestCase):
         def f(a, b):
             called.append((a, b))
 
-        class T(MemoryLeakTestCase):
+        class Test(MemoryLeakTestCase):
             auto_generate = {
                 "foo": LeakTest(f, 1, 2),
             }
@@ -396,8 +396,8 @@ class TestAutoGenerate(unittest.TestCase):
                 fun()
                 calls.append((fun, kwargs))
 
-        t = T("test_leak_foo")
-        t.test_leak_foo()
+        test = Test("test_leak_foo")
+        test.test_leak_foo()
 
         assert called == [(1, 2)]
         assert calls[0][1] == {}
@@ -405,7 +405,7 @@ class TestAutoGenerate(unittest.TestCase):
     def test_execute_kwargs_override(self):
         calls = []
 
-        class T(MemoryLeakTestCase):
+        class Test(MemoryLeakTestCase):
             auto_generate = {
                 "foo": LeakTest(
                     lambda: None,
@@ -417,8 +417,8 @@ class TestAutoGenerate(unittest.TestCase):
             def execute(self, fun, **kwargs):
                 calls.append((fun, kwargs))
 
-        t = T("test_leak_foo")
-        t.test_leak_foo()
+        test = Test("test_leak_foo")
+        test.test_leak_foo()
 
         assert len(calls) == 1
         _, kwargs = calls[0]
@@ -430,7 +430,7 @@ class TestAutoGenerate(unittest.TestCase):
     def test_execute_kwargs_do_not_leak_between_tests(self):
         calls = []
 
-        class T(MemoryLeakTestCase):
+        class Test(MemoryLeakTestCase):
             auto_generate = {
                 "a": LeakTest(lambda: None, times=1),
                 "b": LeakTest(lambda: None, times=2),
@@ -439,8 +439,8 @@ class TestAutoGenerate(unittest.TestCase):
             def execute(self, fun, **kwargs):
                 calls.append((fun, kwargs))
 
-        T("test_leak_a").test_leak_a()
-        T("test_leak_b").test_leak_b()
+        Test("test_leak_a").test_leak_a()
+        Test("test_leak_b").test_leak_b()
 
         assert calls[0][1] == {"times": 1}
         assert calls[1][1] == {"times": 2}
@@ -454,7 +454,7 @@ class TestAutoGenerate(unittest.TestCase):
     def test_rejects_non_leaktest_entry(self):
         with pytest.raises(TypeError):
 
-            class T(MemoryLeakTestCase):
+            class Test(MemoryLeakTestCase):
                 auto_generate = {
                     "bad": lambda: None,
                 }
@@ -462,7 +462,7 @@ class TestAutoGenerate(unittest.TestCase):
     def test_name_collision(self):
         with pytest.raises(RuntimeError):
 
-            class T(MemoryLeakTestCase):
+            class Test(MemoryLeakTestCase):
                 auto_generate = {
                     "foo": LeakTest(lambda: None),
                 }
@@ -477,7 +477,7 @@ class TestAutoGenerate(unittest.TestCase):
         def f(a, b):
             called.append((a, b))
 
-        class T(MemoryLeakTestCase):
+        class Test(MemoryLeakTestCase):
             auto_generate = {
                 "foo": LeakTest(f, 1, 2, times=5),
             }
@@ -486,10 +486,8 @@ class TestAutoGenerate(unittest.TestCase):
                 fun()
                 calls.append((fun, kwargs))
 
-        t = T("test_leak_foo")
-        t.test_leak_foo()
+        test = Test("test_leak_foo")
+        test.test_leak_foo()
 
-        # args passed correctly
         assert called == [(1, 2)]
-        # execute kwargs passed correctly
         assert calls[0][1] == {"times": 5}

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -367,7 +367,7 @@ class TestAutoGenerate(unittest.TestCase):
         class Test(MemoryLeakTestCase):
             @classmethod
             def auto_generate(cls):
-                return {"foo": LeakTest(lambda self: None)}
+                return {"foo": LeakTest(lambda: None)}
 
             def execute(self, fun, **kwargs):
                 calls.append((fun, kwargs))
@@ -406,9 +406,7 @@ class TestAutoGenerate(unittest.TestCase):
         class Test(MemoryLeakTestCase):
             @classmethod
             def auto_generate(cls):
-                return {
-                    "foo": LeakTest(lambda self: None, times=10, tolerance=123)
-                }
+                return {"foo": LeakTest(lambda: None, times=10, tolerance=123)}
 
             def execute(self, fun, **kwargs):
                 calls.append((fun, kwargs))
@@ -423,8 +421,8 @@ class TestAutoGenerate(unittest.TestCase):
             @classmethod
             def auto_generate(cls):
                 return {
-                    "a": LeakTest(lambda self: None, times=1),
-                    "b": LeakTest(lambda self: None, times=2),
+                    "a": LeakTest(lambda: None, times=1),
+                    "b": LeakTest(lambda: None, times=2),
                 }
 
             def execute(self, fun, **kwargs):
@@ -441,7 +439,7 @@ class TestAutoGenerate(unittest.TestCase):
             class Test(MemoryLeakTestCase):
                 @classmethod
                 def auto_generate(cls):
-                    return {"foo": LeakTest(lambda self: None)}
+                    return {"foo": LeakTest(lambda: None)}
 
                 def test_leak_foo(self):
                     pass


### PR DESCRIPTION
In order to avoid writing many similar test methods by hand, ``MemoryLeakTestCase`` can now auto-generate test methods from a declarative specification:


```python
import numpy as np

from psleak import MemoryLeakTestCase, LeakTest

class TestNumpyLeaks(MemoryLeakTestCase):
    @classmethod
    def auto_generate(cls):
        return {
            "zeros": LeakTest(np.zeros, 10),
            "add": LeakTest(np.add, 1, 2),
            "custom": LeakTest(
                np.dot,
                [1, 2],
                [3, 4],
                times=10,
                tolerance=1024,
            ),
        }
```

This will define the following test methods: ``test_leak_zeros``, ``test_leak_add``, ``test_leak_custom``.
