### PR TITLE
Detect refcount bugs: references gained or lost by the tested function

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,12 @@ XXXX-XX-XX
 - 5bd192c: the ``times`` escalation is now capped at 400, so leaky functions
   fail sooner.
 - 3a06853: dropped the 20% run-over-run shortcut from the fade heuristic.
+- 11_: new ``refcounts`` checker (enabled by default): the refcounts of the
+  arguments passed to ``execute()`` are sampled before and after the call. A
+  function which permanently gains or loses references to them (e.g. a
+  ``Py_INCREF`` / ``Py_DECREF`` imbalance in a C extension) raises the new
+  ``RefcountError``. These bugs don't show up as memory growth, so the memory
+  checker can't see them.
 
 **API**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,7 +21,7 @@ XXXX-XX-XX
   function which permanently gains or loses references to them (e.g. a
   ``Py_INCREF`` / ``Py_DECREF`` imbalance in a C extension) raises the new
   ``RefcountError``. These bugs don't show up as memory growth, so the memory
-  checker can't see them.
+  checker can't see them. Python >= 3.12 only.
 
 **API**
 

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@
 psleak
 ======
 
-A fast, CI-friendly regression testing framework for detecting **memory leaks**
-and **unclosed resources** in Python C extensions.
+A fast, CI-friendly regression testing framework for detecting **memory
+leaks**, **unclosed resources** and **refcount bugs** in Python C extensions.
 
 It was originally developed as part of `psutil`_ test suite, and later split
 out into a standalone project.
@@ -85,6 +85,37 @@ are monitored:
           return a, b  # cycle preventing GC from collecting
 
 Each category raises a specific assertion error describing what was leaked.
+
+Refcount bug detection
+^^^^^^^^^^^^^^^^^^^^^^
+
+The reference counts of the arguments passed to ``execute()`` are sampled
+before and after calling the function: if the function permanently gains or
+loses references to them, ``RefcountError`` is raised. E.g. Python code
+passing an object to the C function under test:
+
+.. code-block:: python
+
+    obj = MyObject()
+    cext.function(obj)
+
+.. code-block:: c
+
+    static PyObject *
+    function(PyObject *self, PyObject *args) {
+        PyObject *obj;
+
+        if (!PyArg_ParseTuple(args, "O", &obj))  // "O" = borrowed reference
+            return NULL;
+
+        Py_INCREF(obj);  // BUG 1: never released: `obj` is kept alive forever
+
+        Py_DECREF(obj);  // BUG 2 (either bug alone): releasing a reference we
+                         // don't own: `obj` is freed while the caller still
+                         // uses it, crashing the interpreter later on
+
+        Py_RETURN_NONE;
+    }
 
 Install
 =======

--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,8 @@ Refcount bug detection
 
 The reference counts of the arguments passed to ``execute()`` are sampled
 before and after calling the function: if the function permanently gains or
-loses references to them, ``RefcountError`` is raised. E.g. Python code
-passing an object to the C function under test:
+loses references to them, ``RefcountError`` is raised (Python >= 3.12 only).
+E.g. Python code passing an object to the C function under test:
 
 .. code-block:: python
 

--- a/psleak.py
+++ b/psleak.py
@@ -614,7 +614,10 @@ class MemoryLeakTestCase(unittest.TestCase):
     def _get_counters(self, checkers):
         # order matters
         d = {}
-        if checkers.refcounts:
+        # Only on 3.12+, where shared objects like small ints are
+        # immortal (PEP 683). On older versions an argument like `1`
+        # has a refcount that moves on its own: false positives.
+        if checkers.refcounts and sys.version_info >= (3, 12):
             d["refcounts"] = (
                 [sys.getrefcount(x) for x in self._watched],
                 self._watched,

--- a/psleak.py
+++ b/psleak.py
@@ -139,6 +139,31 @@ class UncollectableGarbageError(UnclosedResourceError):
     verb = "uncollectable"
 
 
+class RefcountError(Error):
+    """Raised when calling the function changes the reference count of
+    one of its arguments. Typically a C extension calling Py_INCREF
+    with no matching Py_DECREF, which keeps the object alive forever,
+    or an extra Py_DECREF, which frees an object still in use and
+    crashes the interpreter later on, usually from unrelated code.
+    """
+
+    def __init__(self, fun_name, diffs):
+        self.fun_name = fun_name
+        self.diffs = diffs
+        self.count = sum(abs(n) for _, n in diffs)
+        noun = "change" + ("s" if self.count > 1 else "")
+        msg = (
+            f"detected {self.count} refcount {noun} after calling"
+            f" {fun_name!r} 1 time:"
+        )
+        lines = []
+        for obj, n in diffs:
+            verb = "gained" if n > 0 else "lost"
+            refs = "reference" + ("s" if abs(n) > 1 else "")
+            lines.append(f"\n* {verb} {abs(n)} {refs} to {obj!r}")
+        super().__init__(msg + "".join(lines))
+
+
 class MemoryLeakError(Error):
     """Raised when a memory leak is detected after calling function
     many times. Aims to detect:
@@ -344,6 +369,7 @@ class Checkers:
     # Python stuff
     py_threads: bool = True
     gcgarbage: bool = True
+    refcounts: bool = True
 
     @classmethod
     def _validate(cls, check_names):
@@ -588,6 +614,11 @@ class MemoryLeakTestCase(unittest.TestCase):
     def _get_counters(self, checkers):
         # order matters
         d = {}
+        if checkers.refcounts:
+            d["refcounts"] = (
+                [sys.getrefcount(x) for x in self._watched],
+                self._watched,
+            )
         if checkers.py_threads:
             d["py_threads"] = (
                 threading.active_count(),
@@ -672,6 +703,19 @@ class MemoryLeakTestCase(unittest.TestCase):
         for what, (count_before, extras_before) in before.items():
             count_after = after[what][0]
             extras_after = after[what][1]
+
+            if what == "refcounts":
+                diffs = [
+                    (obj, a - b)
+                    for obj, b, a in zip(
+                        extras_before, count_before, count_after
+                    )
+                    if a != b
+                ]
+                if diffs:
+                    return RefcountError(qualname(fun), diffs)
+                continue
+
             diff = count_after - count_before
 
             if diff < 0:
@@ -885,6 +929,7 @@ class MemoryLeakTestCase(unittest.TestCase):
         warm_caches()
         _FdsBaseline.get()
 
+        self._watched = args
         if args:
             fun = functools.partial(fun, *args)
 
@@ -919,7 +964,7 @@ class MemoryLeakTestCase(unittest.TestCase):
         test fails.
         """
 
-        def call():
+        def call(*args):  # noqa: ARG001
             try:
                 self.call(fun)
             except exc:
@@ -930,4 +975,4 @@ class MemoryLeakTestCase(unittest.TestCase):
         if args:
             fun = functools.partial(fun, *args)
 
-        self.execute(call, **kwargs)
+        self.execute(call, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,9 @@ omit = [
 ]
 
 [tool.rstcheck]
+ignore_languages = [
+    "c",
+]
 ignore_messages = [
     "Hyperlink target \"\\d+\" is not referenced",
 ]

--- a/tests/test_c_leaks.py
+++ b/tests/test_c_leaks.py
@@ -14,8 +14,10 @@ from psutil import POSIX
 from psutil import WINDOWS
 
 from psleak import NOISE_FLOOR
+from psleak import Checkers
 from psleak import MemoryLeakError
 from psleak import MemoryLeakTestCase
+from psleak import RefcountError
 from psleak import UnclosedHeapCreateError
 from psleak import UnclosedNativeThreadError
 
@@ -232,6 +234,38 @@ class TestPythonExtensionLeaks(MemoryLeakTestCase):
     def test_leak_cycle(self):
         with pytest.raises(MemoryLeakError):
             self.execute(cext.leak_cycle)
+
+
+class TestRefcounts(MemoryLeakTestCase):
+    checkers = Checkers.only("refcounts")
+
+    def test_incref_arg(self):
+        with pytest.raises(RefcountError) as cm:
+            self.execute(cext.incref_arg, object())
+        assert "gained 1 reference" in str(cm.value)
+
+    def test_decref_arg(self):
+        ncalls = 0
+
+        def fun(x):
+            nonlocal ncalls
+            ncalls += 1
+            cext.decref_arg(x)
+
+        obj = object()
+        pin = [obj] * 100  # noqa: F841
+        try:
+            with pytest.raises(RefcountError) as cm:
+                self.execute(fun, obj)
+            assert "lost 1 reference" in str(cm.value)
+        finally:
+            for _ in range(ncalls):
+                cext.incref_arg(obj)
+
+    def test_invisible_to_other_checkers(self):
+        self.execute(
+            cext.incref_arg, object(), checkers=Checkers.exclude("refcounts")
+        )
 
 
 @pytest.mark.skipif(not LINUX, reason="assumes glibc malloc")

--- a/tests/test_c_leaks.py
+++ b/tests/test_c_leaks.py
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import ctypes
+import sys
 import threading
 
 import pytest
@@ -236,6 +237,9 @@ class TestPythonExtensionLeaks(MemoryLeakTestCase):
             self.execute(cext.leak_cycle)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="refcounts checker needs Python 3.12+"
+)
 class TestRefcounts(MemoryLeakTestCase):
     checkers = Checkers.only("refcounts")
 

--- a/tests/test_ext.c
+++ b/tests/test_ext.c
@@ -389,6 +389,33 @@ leak_cycle(PyObject *self, PyObject *args) {
 }
 
 
+// Py_INCREF an argument, forgetting the matching Py_DECREF. The
+// object is kept alive forever, but since it already existed no
+// memory is allocated.
+PyObject *
+incref_arg(PyObject *self, PyObject *args) {
+    PyObject *obj;
+
+    if (!PyArg_ParseTuple(args, "O", &obj))
+        return NULL;
+    Py_INCREF(obj);
+    Py_RETURN_NONE;
+}
+
+
+// Py_DECREF a reference we don't own (PyArg_ParseTuple's "O" is
+// borrowed).
+PyObject *
+decref_arg(PyObject *self, PyObject *args) {
+    PyObject *obj;
+
+    if (!PyArg_ParseTuple(args, "O", &obj))
+        return NULL;
+    Py_DECREF(obj);
+    Py_RETURN_NONE;
+}
+
+
 // --- PyMem
 
 PyObject *
@@ -456,7 +483,9 @@ pyobject_free(PyObject *self, PyObject *args) {
 
 
 static PyMethodDef TestExtMethods[] = {
+    {"decref_arg", decref_arg, METH_VARARGS, ""},
     {"free", psleak_free, METH_VARARGS, ""},
+    {"incref_arg", incref_arg, METH_VARARGS, ""},
     {"leak_cycle", leak_cycle, METH_VARARGS, ""},
     {"leak_dict", leak_dict, METH_VARARGS, ""},
     {"leak_list", leak_list, METH_VARARGS, ""},

--- a/tests/test_python_leaks.py
+++ b/tests/test_python_leaks.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import ctypes
 import mmap
 import threading
 
@@ -11,6 +12,7 @@ from psleak import Checkers
 from psleak import GCDebugger
 from psleak import MemoryLeakError
 from psleak import MemoryLeakTestCase
+from psleak import RefcountError
 from psleak import UnclosedPythonThreadError
 from psleak import UncollectableGarbageError
 
@@ -113,6 +115,42 @@ class TestUncollectableGarbage(MemoryLeakTestCase):
             return err
 
         self.execute(create_exception)
+
+
+class TestRefcounts(MemoryLeakTestCase):
+    checkers = Checkers.only("refcounts")
+
+    def test_gained_ref(self):
+        cache = []
+
+        def fun(x):
+            cache.append(x)
+
+        with pytest.raises(RefcountError) as cm:
+            self.execute(fun, object())
+        assert "gained 1 reference" in str(cm.value)
+
+    def test_lost_ref(self):
+        decref = ctypes.pythonapi.Py_DecRef
+        decref.argtypes = [ctypes.py_object]
+        incref = ctypes.pythonapi.Py_IncRef
+        incref.argtypes = [ctypes.py_object]
+        ncalls = 0
+
+        def fun(x):
+            nonlocal ncalls
+            ncalls += 1
+            decref(x)
+
+        obj = object()
+        pin = [obj] * 100  # noqa: F841
+        try:
+            with pytest.raises(RefcountError) as cm:
+                self.execute(fun, obj)
+            assert "lost 1 reference" in str(cm.value)
+        finally:
+            for _ in range(ncalls):
+                incref(obj)
 
 
 class TestGCDebugger(MemoryLeakTestCase):

--- a/tests/test_python_leaks.py
+++ b/tests/test_python_leaks.py
@@ -4,6 +4,7 @@
 
 import ctypes
 import mmap
+import sys
 import threading
 
 import pytest
@@ -117,6 +118,9 @@ class TestUncollectableGarbage(MemoryLeakTestCase):
         self.execute(create_exception)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="refcounts checker needs Python 3.12+"
+)
 class TestRefcounts(MemoryLeakTestCase):
     checkers = Checkers.only("refcounts")
 


### PR DESCRIPTION
Add a new `refcounts` checker (enabled by default): the arguments passed to `execute()` are sampled with `sys.getrefcount()` before/after one call of the tested function. It catches the two classic C extension refcount mistakes.

E.g. a Python function passing an object to the C function:

```python
obj = MyObject()
cext.function(obj)
```

...and the C function either incref-s or decref-s the object:

```c
static PyObject *
function(PyObject *self, PyObject *args) {
    PyObject *obj;

    if (!PyArg_ParseTuple(args, "O", &obj))  // "O" = borrowed reference
        return NULL;
    ...
    Py_INCREF(obj);  // BUG 1: never released. `obj` is kept alive forever,
                     // but nothing was allocated

    Py_DECREF(obj);  // BUG 2: releasing a reference we don't own ("O" is
                     // borrowed). `obj` is freed while the caller still uses it,
                     // crashing the interpreter later on.

    Py_RETURN_NONE;
}
```

Neither bug shows up as a memory increase in heap / RSS / VMS etc., which is what the memory checker looks for. That is why this needs its own check. Note: immortal objects (`None`, `True`, small ints, interned string literals; [PEP 683](https://peps.python.org/pep-0683/)) have pinned refcounts, so mistakes on those are both harmless and undetectable.